### PR TITLE
Added additional tests for issue #13

### DIFF
--- a/src/test/java/com/markit/EmptyTextWatermarkExceptionTest.kt
+++ b/src/test/java/com/markit/EmptyTextWatermarkExceptionTest.kt
@@ -1,0 +1,59 @@
+package com.markit
+
+import com.markit.api.WatermarkPosition
+import com.markit.api.WatermarkService
+import com.markit.api.WatermarkingMethod
+import com.markit.exceptions.EmptyWatermarkTextException
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.common.PDRectangle
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.PrintStream
+
+
+class EmptyTextWatermarkExceptionTest {
+    private lateinit var document: PDDocument
+    private val originalErr = System.err
+    private lateinit var errContent: ByteArrayOutputStream
+
+    @BeforeEach
+    fun initDocument() {
+        document = PDDocument().apply {
+            addPage(PDPage(PDRectangle.A4))
+        }
+        // Capture log output for verification
+        errContent = ByteArrayOutputStream()
+        System.setErr(PrintStream(errContent))
+    }
+
+    @AfterEach
+    fun close() {
+        document.close()
+        System.setErr(originalErr)
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given empty withText when draw method then throw exception`() {
+
+        assertThrows<EmptyWatermarkTextException> {
+            WatermarkService.textBasedWatermarker()
+                .watermark(document)
+                .withText("")
+                .position(WatermarkPosition.CENTER)
+                .method(WatermarkingMethod.DRAW)
+                .apply()
+        }
+        // Verify log that contains the expected error log
+        val loggedMessage = errContent.toString().trim()
+        assert(loggedMessage.contains("the watermarking text is empty")) {
+            "Expected log message not found. Logged: $loggedMessage"
+        }
+
+    }
+}

--- a/src/test/java/com/markit/PdfImageWatermarkTest.kt
+++ b/src/test/java/com/markit/PdfImageWatermarkTest.kt
@@ -1,0 +1,93 @@
+package com.markit
+
+import com.markit.api.WatermarkService
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.common.PDRectangle
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.nio.file.Files
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PdfImageWatermarkTest {
+    private lateinit var document: PDDocument
+
+    @BeforeEach
+    fun initDocument() {
+        document = PDDocument().apply {
+            addPage(PDPage(PDRectangle.A4))
+        }
+    }
+
+    @AfterEach
+    fun close() {
+        document.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Image Watermark with 180 Degree Rotation then Apply Watermark`() {
+        // When
+        val result = WatermarkService.imageBasedWatermarker()
+            .watermark(document)
+            .withImage(readFileFromClasspathAsBytes("logo.png")).size(25)
+            .rotation(180)
+            .position(com.markit.api.WatermarkPosition.TILED)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "ImageBasedWatermarkRotation.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Image Watermark and DPI then Apply Watermark`() {
+        // When
+        val result = WatermarkService.imageBasedWatermarker()
+            .watermark(document)
+            .withImage(readFileFromClasspathAsBytes("logo.png")).size(25)
+            .dpi(100f)
+            .position(com.markit.api.WatermarkPosition.TILED)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "ImageBasedWatermarkDPI.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Image Watermark and Adjust then Apply Watermark`() {
+        // When
+        val result = WatermarkService.imageBasedWatermarker()
+            .watermark(document)
+            .withImage(readFileFromClasspathAsBytes("logo.png")).size(25)
+            .position(com.markit.api.WatermarkPosition.TILED)
+            .adjust(50, 50)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "ImageBasedWatermarkAdjust.pdf")
+    }
+
+    fun readFileFromClasspathAsBytes(fileName: String): ByteArray? {
+        val classLoader = Thread.currentThread().contextClassLoader
+        val inputStream: InputStream? = classLoader.getResourceAsStream(fileName)
+        return inputStream?.readBytes()
+    }
+
+    private fun outputFile(result: ByteArray, filename: String) {
+        val outputFile = File(filename)
+        Files.write(outputFile.toPath(), result)
+    }
+}

--- a/src/test/java/com/markit/PdfImageWatermarkTest.kt
+++ b/src/test/java/com/markit/PdfImageWatermarkTest.kt
@@ -53,7 +53,7 @@ class PdfImageWatermarkTest {
         val result = WatermarkService.imageBasedWatermarker()
             .watermark(document)
             .withImage(readFileFromClasspathAsBytes("logo.png")).size(25)
-            .dpi(100f)
+            .dpi(100)
             .position(com.markit.api.WatermarkPosition.TILED)
             .apply()
 

--- a/src/test/java/com/markit/PdfPageRotationTextBasedWatermarkTest.kt
+++ b/src/test/java/com/markit/PdfPageRotationTextBasedWatermarkTest.kt
@@ -1,0 +1,78 @@
+package com.markit
+
+import com.markit.api.WatermarkingMethod
+import com.markit.api.WatermarkPosition
+import com.markit.api.WatermarkService
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.common.PDRectangle
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+
+class PdfPageRotationTextBasedWatermarkTest {
+    private lateinit var document: PDDocument
+
+    @BeforeEach
+    fun initDocument() {
+        document = PDDocument().apply {
+            addPage(PDPage(PDRectangle.A4).apply { rotation = 0 })
+            addPage(PDPage(PDRectangle.A4).apply { rotation = 90 })
+            addPage(PDPage(PDRectangle.A4).apply { rotation = 180 })
+            addPage(PDPage(PDRectangle.A4).apply { rotation = 270 })
+        }
+    }
+
+    @AfterEach
+    fun close() {
+        document.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf with 0, 90, 180 and 270 degrees page rotation when Draw Method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Sample Watermark")
+            .size(50)
+            .position(WatermarkPosition.CENTER)
+            .method(WatermarkingMethod.DRAW)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "PDFwithDifferentPagesRotatedDraw.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf with 0, 90, 180 and 270 degrees page rotation when Overlay Method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Sample Watermark")
+            .size(50)
+            .position(WatermarkPosition.CENTER)
+            .method(WatermarkingMethod.OVERLAY)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "PDFwithDifferentPagesRotatedOverlay.pdf")
+    }
+
+
+    private fun outputFile(result: ByteArray, filename: String) {
+        val outputFile = File(filename)
+        Files.write(outputFile.toPath(), result)
+    }
+}

--- a/src/test/java/com/markit/PdfTextBasedWatermarkPositionTest.kt
+++ b/src/test/java/com/markit/PdfTextBasedWatermarkPositionTest.kt
@@ -1,0 +1,226 @@
+package com.markit
+
+import com.markit.api.WatermarkPosition
+import com.markit.api.WatermarkService
+import com.markit.api.WatermarkingMethod
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.common.PDRectangle
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PdfTextBasedWatermarkPositionTest {
+    private lateinit var document: PDDocument
+
+    @BeforeEach
+    fun initDocument() {
+        document = PDDocument().apply {
+            addPage(PDPage(PDRectangle.A4))
+        }
+    }
+
+    @AfterEach
+    fun close() {
+        document.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Center Position and Draw method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Center Watermark")
+            .position(WatermarkPosition.CENTER)
+            .method(WatermarkingMethod.DRAW)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "TextBasedDrawWatermarkPositionCenter.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Top Left Position and Draw method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Top Left Watermark")
+            .position(WatermarkPosition.TOP_LEFT)
+            .method(WatermarkingMethod.DRAW)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "TextBasedDrawWatermarkPositionTopLeft.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Top Right Position and Draw method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Top Right Watermark")
+            .position(WatermarkPosition.TOP_RIGHT)
+            .method(WatermarkingMethod.DRAW)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "TextBasedDrawWatermarkPositionTopRight.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Bottom Left Position and Draw method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Bottom Left Watermark")
+            .position(WatermarkPosition.BOTTOM_LEFT)
+            .method(WatermarkingMethod.DRAW)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "TextBasedDrawWatermarkPositionBottomLeft.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Bottom Right Position and Draw method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Bottom Right Watermark")
+            .position(WatermarkPosition.BOTTOM_RIGHT)
+            .method(WatermarkingMethod.DRAW)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "TextBasedDrawWatermarkPositionBottomRight.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Tiled Position and Draw method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Tiled Watermark")
+            .position(WatermarkPosition.TILED)
+            .method(WatermarkingMethod.DRAW)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "TextBasedDrawWatermarkPositionTiled.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Center Position and Overlay method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Center Watermark").size(25)
+            .position(WatermarkPosition.CENTER)
+            .method(WatermarkingMethod.OVERLAY)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "TextBasedOverlayWatermarkPositionCenter.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Top Left Position and Overlay method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Top Left Watermark").size(25)
+            .position(WatermarkPosition.TOP_LEFT)
+            .method(WatermarkingMethod.OVERLAY)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "TextBasedOverlayWatermarkPositionTopLeft.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Top Right Position and Overlay method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Top Right Watermark").size(25)
+            .position(WatermarkPosition.TOP_RIGHT)
+            .method(WatermarkingMethod.OVERLAY)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "TextBasedOverlayWatermarkPositionTopRight.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Bottom Left Position and Overlay method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Bottom Left Watermark").size(25)
+            .position(WatermarkPosition.BOTTOM_LEFT)
+            .method(WatermarkingMethod.OVERLAY)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "TextBasedOverlayWatermarkPositionBottomLeft.pdf")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `given Pdf when Bottom Right Position and Overlay method then Make Watermarked Pdf`() {
+        // When
+        val result = WatermarkService.textBasedWatermarker()
+            .watermark(document)
+            .withText("Bottom Right Watermark").size(25)
+            .position(WatermarkPosition.BOTTOM_RIGHT)
+            .method(WatermarkingMethod.OVERLAY)
+            .apply()
+
+        // Then
+        assertNotNull(result, "The resulting byte array should not be null")
+        assertTrue(result.isNotEmpty(), "The resulting byte array should not be empty")
+        //outputFile(result, "TextBasedOverlayWatermarkPositionBottomRight.pdf")
+    }
+
+    private fun outputFile(result: ByteArray, filename: String) {
+        val outputFile = File(filename)
+        Files.write(outputFile.toPath(), result)
+    }
+
+}
+


### PR DESCRIPTION
This PR adds additional tests to enhance test coverage

### Changes made:

- EmptyTextWatermarkExceptionTest.kt: Verifies that an exception is thrown and logged when an empty watermark text is provided.
- PdfImageWatermarkTest.kt: Tests the application of image-based watermarks on PDF documents, including scenarios with DPI, rotations, and position adjustments.
- PdfPageRotationTextBasedWatermarkTest.kt: Ensures text-based watermarks are correctly applied to PDF pages with varying rotations (0°, 90°, 180°, and 270°).
- PdfTextBasedWatermarkPositionTest.kt: Validates text-based watermarks at various positions, such as center, corners, and tiled layouts.